### PR TITLE
feat: chip component 구현

### DIFF
--- a/zoo-client/src/app/components/common/badge/Badge.tsx
+++ b/zoo-client/src/app/components/common/badge/Badge.tsx
@@ -1,15 +1,9 @@
 interface IBadgeProps {
-  size: 's' | 'l';
   text: string;
   type: 'fullBooking' | 'subject' | 'default';
 }
 
-export default function Badge({ size, text, type }: IBadgeProps) {
-  const badgeSizeClasses = {
-    l: 'py-4 px-8',
-    s: 'p-4',
-  };
-
+export default function Badge({ text, type }: IBadgeProps) {
   const badgeTypeClasses = {
     fullBooking: 'bg-bg-thirary text-text-thirary',
     subject: 'bg-bg-badge-subject text-text-title',
@@ -18,7 +12,7 @@ export default function Badge({ size, text, type }: IBadgeProps) {
 
   return (
     <div
-      className={`website:body-m-16-150 mobile:body-m-14 inline-flex items-center justify-center gap-0 rounded-sm ${badgeSizeClasses[size]} ${badgeTypeClasses[type]}`}
+      className={`website:body-m-16-150 mobile:body-m-14 inline-flex items-center justify-center gap-0 rounded-sm px-8 py-4 ${badgeTypeClasses[type]}`}
     >
       {text}
     </div>

--- a/zoo-client/src/app/components/common/chip/Chip.tsx
+++ b/zoo-client/src/app/components/common/chip/Chip.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useChipStore } from '@/store/useChipStore';
+
+interface IChipProps {
+  text: string;
+}
+
+export default function Chip({ text }: IChipProps) {
+  const { selectedChips, toggleChip } = useChipStore();
+  const isSelected = selectedChips.has(text);
+
+  return (
+    <div
+      className={`inline-flex items-center justify-center gap-0 rounded-sm website:px-8 website:py-4 ${isSelected ? 'bg-fill-secondary' : 'bg-bg-thirary'}`}
+      onClick={() => toggleChip(text)}
+    >
+      {text}
+    </div>
+  );
+}

--- a/zoo-client/src/app/components/common/chip/ChipList.tsx
+++ b/zoo-client/src/app/components/common/chip/ChipList.tsx
@@ -1,0 +1,15 @@
+import Chip from './Chip';
+
+interface IChipListProps {
+  subjectList: string[];
+}
+
+export default function ChipList({ subjectList }: IChipListProps) {
+  return (
+    <div className="flex w-[77.5rem] flex-wrap content-center items-center gap-x-12 gap-y-[0.75rem]">
+      {subjectList.map((subject, index) => (
+        <Chip key={index} text={subject} />
+      ))}
+    </div>
+  );
+}

--- a/zoo-client/src/app/components/index.ts
+++ b/zoo-client/src/app/components/index.ts
@@ -1,1 +1,2 @@
 export { default as Badge } from './common/badge/Badge';
+export { default as ChipList } from './common/chip/ChipList';

--- a/zoo-client/src/store/useChipStore.ts
+++ b/zoo-client/src/store/useChipStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+interface IChipStore {
+  selectedChips: Set<string>;
+  toggleChip: (text: string) => void;
+}
+
+export const useChipStore = create<IChipStore>((set) => ({
+  selectedChips: new Set(),
+  toggleChip: (text) =>
+    set((state) => {
+      const selectedChips = new Set(state.selectedChips);
+
+      if (selectedChips.has(text)) selectedChips.delete(text);
+      else selectedChips.add(text);
+
+      return { selectedChips };
+    }),
+}));

--- a/zoo-client/src/styles/tokens/colors.ts
+++ b/zoo-client/src/styles/tokens/colors.ts
@@ -110,13 +110,13 @@ const colors = {
       disabled: COLOR_TOKEN['grey-c'][200],
 
       list: '#4824ff',
-      secondary: COLOR_TOKEN.green[500],
-      thirary: COLOR_TOKEN['grey-c'][50],
-
-      'kakao-login': '#fee500',
-      active: COLOR_TOKEN['grey-n'][500],
-      inactive: COLOR_TOKEN['grey-n'][100],
     },
+    secondary: COLOR_TOKEN.green[500],
+    thirary: COLOR_TOKEN['grey-c'][50],
+
+    'kakao-login': '#fee500',
+    active: COLOR_TOKEN['grey-n'][500],
+    inactive: COLOR_TOKEN['grey-n'][100],
   },
 
   /* text */


### PR DESCRIPTION
## ✅ 체크리스트

- [x] chip component 구현
- [x] chip list component 구현

### 추가 변경 사항

- [x] badge component에서 size prop 삭제

## 📝 작업 상세 내용

> chip/chip list component 구현이 완료 되었습니다. chip 한 개만을 개별적으로 사용하는 경우가 아니라면 `ChipList` component를 사용해 주시면 됩니다. 필수 props는 `subjectList` 한 가지입니다. :>

`subjectList`: 세션 주제가 담겨 있는 배열 

```tsx
export default function Home() {
  const subjectList = ['주제 1', '주제 2', '주제 3', '주제 4'];

  return (
    <>
      <ChipList subjectList={subjectList} />
    </>
  );
}
```

### chip component 상세 구현 내용

chip component의 선택 상태를 전역으로 관리하기 위해 `useChipStore`를 구현해 주었습니다. 또한, 주제가 중복될 일이 없고 이미 선택된 칩을 클릭했을 경우에는 선택 상태가 해제되어야 한다고 생각해 `Set()`을 사용해 토글 상태를 관리 중입니다! 자세한 구현 내용은 [a7edf57](https://github.com/Zoo-Goorm/Zoo-Front/commit/a7edf57ca90da74520405811dc80dc9b0a28b591)에서 확인하실 수 있습니다~

```ts
export default function Chip({ text }: IChipProps) {
  const { selectedChips, toggleChip } = useChipStore();
  const isSelected = selectedChips.has(text);

  return (
    <div
      className={`inline-flex items-center justify-center gap-0 rounded-sm website:px-8 website:py-4 ${isSelected ? 'bg-fill-secondary' : 'bg-bg-thirary'}`}
      onClick={() => toggleChip(text)}
    >
      {text}
    </div>
  );
}
```

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #6 
