### PR TITLE
feat: 비회원 페이지 UI 구현

### DIFF
--- a/zoo-client/next.config.ts
+++ b/zoo-client/next.config.ts
@@ -1,6 +1,15 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/login',
+        permanent: true,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/zoo-client/src/apis/index.ts
+++ b/zoo-client/src/apis/index.ts
@@ -1,0 +1,3 @@
+const baseURL = `${process.env.NEXT_PUBLIC_API_URL}`;
+
+export default baseURL;

--- a/zoo-client/src/app/login/page.tsx
+++ b/zoo-client/src/app/login/page.tsx
@@ -1,3 +1,4 @@
+import baseURL from '@/apis';
 import { LoginButton, NavigationBar } from '@/components';
 import { LOGIN_PAGE_MESSAGE } from '@/constants/messages';
 
@@ -15,9 +16,15 @@ export default function Login() {
           </p>
         </div>
         <div className="flex flex-col items-start gap-16 self-stretch">
-          <LoginButton type="kakao" />
-          <LoginButton type="google" />
-          <LoginButton type="nonMember" />
+          <LoginButton
+            type="kakao"
+            loginRouter={`${baseURL}/oauth2/authorization/kako`}
+          />
+          <LoginButton
+            type="google"
+            loginRouter={`${baseURL}/oauth2/authorization/google`}
+          />
+          <LoginButton loginRouter="/none-member" type="nonMember" />
         </div>
       </div>
     </div>

--- a/zoo-client/src/app/none-member/page.tsx
+++ b/zoo-client/src/app/none-member/page.tsx
@@ -1,0 +1,11 @@
+import { Footer, NavigationBar, NoneMemberForm } from '@/components';
+
+export default function NoneMember() {
+  return (
+    <div className="flex h-[100vh] w-[100vw] flex-col items-center gap-[6.25rem]">
+      <NavigationBar />
+      <NoneMemberForm />
+      <Footer />
+    </div>
+  );
+}

--- a/zoo-client/src/app/none-member/page.tsx
+++ b/zoo-client/src/app/none-member/page.tsx
@@ -2,7 +2,7 @@ import { Footer, NavigationBar, NoneMemberForm } from '@/components';
 
 export default function NoneMember() {
   return (
-    <div className="flex h-[100vh] w-[100vw] flex-col items-center gap-[6.25rem]">
+    <div className="flex w-[100vw] flex-col items-center gap-[6.25rem]">
       <NavigationBar />
       <NoneMemberForm />
       <Footer />

--- a/zoo-client/src/components/common/button/LoginButton.tsx
+++ b/zoo-client/src/components/common/button/LoginButton.tsx
@@ -1,10 +1,16 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import LoginIcon from './icon/LoginIcon';
 
 interface ILoginButtonProps {
+  loginRouter: string;
   type: 'kakao' | 'google' | 'nonMember';
 }
 
-export default function LoginButton({ type }: ILoginButtonProps) {
+export default function LoginButton({ type, loginRouter }: ILoginButtonProps) {
+  const router = useRouter();
+
   const ButtonTypeClasses = {
     kakao: 'bg-fill-kakao-login border-none',
     google: 'bg-bg-primary border-stroke-thirary border border-solid',
@@ -24,6 +30,7 @@ export default function LoginButton({ type }: ILoginButtonProps) {
 
   return (
     <button
+      onClick={() => router.push(loginRouter)}
       className={`website:title-sb-18 mobile:body-sb-16 flex items-center justify-center gap-8 rounded-[0.25rem] px-44 py-12 text-text-main mobile:w-[17.5rem] website:w-[100%] ${ButtonTypeClasses[type]}`}
     >
       {type === 'nonMember' ? undefined : (

--- a/zoo-client/src/components/common/button/OblongButton.tsx
+++ b/zoo-client/src/components/common/button/OblongButton.tsx
@@ -6,7 +6,7 @@ interface IOblongButtonProps {
   $disabled?: boolean;
   text: string;
   type?: 'button' | 'submit';
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 export default function OblongButton({
@@ -47,7 +47,7 @@ export default function OblongButton({
     <button
       onClick={onClick}
       type={type}
-      className={`inline-flex items-center rounded-[0.25rem] ${buttonSizeClasses[size]} ${buttonStateClasses[$buttonStyle]}`}
+      className={`flex w-[100%] items-center justify-center rounded-[0.25rem] text-center ${buttonSizeClasses[size]} ${buttonStateClasses[$buttonStyle]}`}
     >
       {text}
       {$buttonStyle === 'primary' ? (
@@ -57,7 +57,7 @@ export default function OblongButton({
           width={iconSize}
           height={iconSize}
         />
-      ) : undefined}
+      ) : null}
     </button>
   );
 }

--- a/zoo-client/src/components/common/textField/TextField.tsx
+++ b/zoo-client/src/components/common/textField/TextField.tsx
@@ -2,9 +2,10 @@ import OblongButton from '../button/OblongButton';
 import { UseFormRegister, RegisterOptions } from 'react-hook-form';
 
 interface ITextField {
-  type: 'default' | 'badgeField';
+  type: 'default' | 'badgeField' | 'time';
   state?: 'default' | 'disabled' | 'error';
   applyItem: string;
+  $isDisabled?: boolean;
   $isRequired: boolean;
   readOnly?: boolean;
   buttonText?: string;
@@ -26,6 +27,7 @@ export default function TextField({
   readOnly = false,
   errorMessage,
   placeholder,
+  $isDisabled,
   $isRequired,
   name,
   rules,
@@ -64,13 +66,19 @@ export default function TextField({
           </label>
         )}
       </div>
+      {type === 'time' && (
+        <span className="figure-m-16 text-text-primary">05:00</span>
+      )}
       {buttonText && onButtonClick && (
-        <OblongButton
-          onClick={onButtonClick}
-          size="xs"
-          $buttonStyle="primary"
-          text={buttonText}
-        />
+        <div className="w-[6.25rem]">
+          <OblongButton
+            $disabled={$isDisabled}
+            onClick={onButtonClick}
+            size="xs"
+            $buttonStyle="primary"
+            text={buttonText}
+          />
+        </div>
       )}
     </div>
   );

--- a/zoo-client/src/components/index.ts
+++ b/zoo-client/src/components/index.ts
@@ -47,6 +47,7 @@ export { default as CardContent } from './common/card/CardContent';
 /* form */
 export { default as TextField } from './common/textField/TextField';
 export { default as RegisterForm } from './register/RegisterForm';
+export { default as NoneMemberForm } from './noneMember/NoneMemberForm';
 
 /* modal */
 export { default as AlertModal } from './common/modal/AlertModal';

--- a/zoo-client/src/components/noneMember/NoneMemberForm.tsx
+++ b/zoo-client/src/components/noneMember/NoneMemberForm.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+import { AlertModal, OblongButton, TextField } from '@/components';
+import { useState } from 'react';
+import useModalStore from '@/store/common/useModalStore';
+
+interface FormData {
+  name: string;
+  email: string;
+  authenticationCode: string;
+}
+
+export default function NoneMemberForm() {
+  const router = useRouter();
+  const [isAuthenticationClicked, setIsAuthenticationClicked] = useState(false);
+  const { isOpen, contents, openModal, closeModal } = useModalStore();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitSuccessful },
+  } = useForm<FormData>({
+    defaultValues: {
+      name: '',
+      email: '',
+      authenticationCode: '',
+    },
+  });
+
+  const onSubmit: SubmitHandler<FormData> = (data) => {
+    console.log(data);
+    if (isSubmitSuccessful) router.push('/session-schedule');
+  };
+
+  const handleAuthenticationButton = () => {
+    openModal({
+      contents: (
+        <AlertModal
+          headerText="비회원 이메일 인증"
+          buttonText="확인"
+          onButtonClick={closeModal}
+          bodyText={`서비스를 이용하려면 이메일 인증이 필요합니다.\n등록하신 [이메일]로 인증 메일을 발송했으니, 확인 후 인증을 완료해주세요.`}
+        />
+      ),
+    });
+
+    setIsAuthenticationClicked(true);
+  };
+
+  const openCancelModal = () => {
+    openModal({
+      contents: (
+        <AlertModal
+          headerText="알림"
+          buttonText="확인"
+          onButtonClick={() => router.push('/login')}
+          bodyText="페이지를 나가면 입력하신 정보가 초기화됩니다."
+        />
+      ),
+    });
+  };
+
+  return (
+    <div className="flex w-[100%] max-w-[77.5rem] flex-col items-center justify-center gap-60">
+      <h1 className="website:display-b-48 mobile:headline-sb-32 flex w-[100%] items-start text-text-main">
+        비회원 정보 입력
+      </h1>
+      <form
+        className="flex w-[100%] flex-col items-start justify-center gap-36"
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <TextField
+          $isRequired
+          name="name"
+          type="default"
+          applyItem="이름"
+          placeholder="이름"
+          register={register}
+          state={errors.name ? 'error' : 'default'}
+          rules={{ required: '이름은 필수 입력 항목입니다.' }}
+          errorMessage={errors.name?.message}
+        />
+        <TextField
+          $isRequired
+          name="email"
+          type="default"
+          applyItem="이메일"
+          placeholder="이메일"
+          register={register}
+          buttonText="이메일 인증"
+          onButtonClick={handleAuthenticationButton}
+          state={errors.email ? 'error' : 'default'}
+          rules={{ required: '이메일은 필수 입력 항목입니다.' }}
+          errorMessage={errors.email?.message}
+        />
+        <TextField
+          readOnly={!isAuthenticationClicked}
+          $isRequired
+          name="authenticationCode"
+          type={isAuthenticationClicked ? 'time' : 'default'}
+          applyItem="인증 번호"
+          placeholder="인증 번호"
+          register={register}
+          state={errors.authenticationCode ? 'error' : 'default'}
+          rules={{ required: '인증 번호은 필수 입력 항목입니다.' }}
+          errorMessage={errors.authenticationCode?.message}
+        />
+        <span className="body-m-16 w-[100%] text-text-sub">
+          본인 확인 절차이며, 다른 용도로 사용되지 않습니다.
+        </span>
+        <div className="flex w-[100%] items-center gap-3">
+          <div className="mobile:w-[9.375rem] website:w-[5.31251rem]">
+            <OblongButton
+              size="m"
+              type="button"
+              $buttonStyle="thirary"
+              text="취소"
+              onClick={openCancelModal}
+            />
+          </div>
+          <div className="mobile:w-[9.375rem] website:w-[11.5625rem]">
+            <OblongButton
+              size="m"
+              type="submit"
+              $buttonStyle="primary"
+              text="다음"
+            />
+          </div>
+        </div>
+      </form>
+      {isOpen && contents}
+    </div>
+  );
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 비회원 페이지 UI 구현

### ✨ 추가 작업 리스트

- [x] 로그인 페이지 버튼 router 연결 
- [x] 초기 화면 로그인 페이지로 변경

## 📝 작업 상세 내용

> 비회원 페이지 UI 구현을 완료했습니다. 빠르게 임시로 구현한 거라 코드가 정돈되어 있지 않고 플로우대로 동작하지 않는 것들이 많습니다. 추후 기능 붙일 때 다듬어서 작업하도록 하겠습니다. 😭

![스크린샷 2025-03-17 오후 5 03 14](https://github.com/user-attachments/assets/649c3c4a-ae28-4b65-bafc-460b5f1d6bfb)

> 추가적으로 로그인 페이지 버튼에 router를 연결해 주었습니다. 각 버튼 클릭 시 버튼에 해당하는 라우터로 이동합니다. 또한, 페이지 처음 접속 시 로그인 페이지로 이동하게 됩니다. (기존에는 /로 이동)

![스크린샷 2025-03-17 오후 5 04 26](https://github.com/user-attachments/assets/23f149a3-154a-4821-9f4d-4e0e7fe44c2f)

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #37 
