### PR TITLE
feat: 소셜 로그인 구현 (kakao/google)

### DIFF
--- a/zoo-client/package.json
+++ b/zoo-client/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query-devtools": "^5.66.9",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
+    "cookies-next": "^5.1.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "next": "^15.2.0",
     "react": "^19.0.0",

--- a/zoo-client/src/apis/index.ts
+++ b/zoo-client/src/apis/index.ts
@@ -1,3 +1,3 @@
-const baseURL = `${process.env.NEXT_PUBLIC_API_URL}`;
+const baseURL = process.env.NEXT_PUBLIC_API_URL;
 
 export default baseURL;

--- a/zoo-client/src/app/login/page.tsx
+++ b/zoo-client/src/app/login/page.tsx
@@ -18,13 +18,13 @@ export default function Login() {
         <div className="flex flex-col items-start gap-16 self-stretch">
           <LoginButton
             type="kakao"
-            loginRouter={`${baseURL}/oauth2/authorization/kako`}
+            loginRouter={`${baseURL}/oauth2/authorization/kakao`}
           />
           <LoginButton
             type="google"
             loginRouter={`${baseURL}/oauth2/authorization/google`}
           />
-          <LoginButton loginRouter="/none-member" type="nonMember" />
+          <LoginButton type="nonMember" loginRouter="/none-member" />
         </div>
       </div>
     </div>

--- a/zoo-client/src/components/common/navigationBar/NavigationBar.tsx
+++ b/zoo-client/src/components/common/navigationBar/NavigationBar.tsx
@@ -1,3 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import useAuthStore from '@/store/common/auth/useAuthStore';
+import useTokenStore from '@/store/common/auth/useTokenStore';
+
 export default function NavigationBar() {
+  const { accessToken } = useTokenStore();
+  const checkAuth = useAuthStore((state) => state.checkAuth);
+
+  useEffect(() => {
+    const authenticate = async () => {
+      if (accessToken) await checkAuth();
+    };
+
+    authenticate();
+  }, [checkAuth]);
+
   return <div className="h-[5rem] self-stretch bg-[#d9d9d9]" />;
 }

--- a/zoo-client/src/services/api.ts
+++ b/zoo-client/src/services/api.ts
@@ -18,6 +18,7 @@ export async function fetchApi<T>(
 
   const response = await fetch(url, {
     ...options,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       ...options.headers,

--- a/zoo-client/src/services/auth.ts
+++ b/zoo-client/src/services/auth.ts
@@ -1,0 +1,23 @@
+import baseURL from '@/apis';
+
+async function fetchAuthToken() {
+  const endpoint = `${baseURL}/api/v1/user/auth/token`;
+
+  const response = await fetch(endpoint, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  if (!response.ok) throw new Error(`HTTP error status: ${response.status}`);
+
+  const authorizationHeader = response.headers.get('Authorization');
+
+  if (authorizationHeader) {
+    const token = authorizationHeader.split(' ')[1];
+    localStorage.setItem('accessToken', token);
+  }
+
+  return null;
+}
+
+export default fetchAuthToken;

--- a/zoo-client/src/store/common/auth/useAuthStore.ts
+++ b/zoo-client/src/store/common/auth/useAuthStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import fetchAuthToken from '@/services/auth';
+
+interface AuthState {
+  checkAuth: () => Promise<void>;
+  getAccessToken: () => void;
+}
+
+interface AuthStore {
+  isAuthenticated: boolean;
+  userToken: string | null;
+}
+
+const useAuthStore = create<AuthState & AuthStore>((set) => ({
+  userToken: '',
+  isAuthenticated: false,
+  checkAuth: async () => {
+    try {
+      await fetchAuthToken();
+    } catch (error) {
+      throw Error(`토큰을 헤더로 변환할 수 없습니다. ${error}`);
+    }
+  },
+  getAccessToken: () => {
+    const accessToken = localStorage.getItem('accessToken') || null;
+    set({ userToken: accessToken });
+  },
+}));
+
+export default useAuthStore;

--- a/zoo-client/src/store/common/auth/useAuthStore.ts
+++ b/zoo-client/src/store/common/auth/useAuthStore.ts
@@ -23,7 +23,11 @@ const useAuthStore = create<AuthState & AuthStore>((set) => ({
   },
   getAccessToken: () => {
     const accessToken = localStorage.getItem('accessToken') || null;
-    set({ userToken: accessToken });
+
+    if (accessToken) {
+      set({ isAuthenticated: true });
+      set({ userToken: accessToken });
+    }
   },
 }));
 

--- a/zoo-client/src/store/common/auth/useTokenStore.ts
+++ b/zoo-client/src/store/common/auth/useTokenStore.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+import { getCookie } from 'cookies-next';
+
+interface TokenState {
+  accessToken: string | null;
+}
+
+const useTokenStore = create<TokenState>(() => ({
+  accessToken: getCookie('Authorization') as string | null,
+}));
+
+export default useTokenStore;

--- a/zoo-client/yarn.lock
+++ b/zoo-client/yarn.lock
@@ -903,6 +903,18 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
+
+cookies-next@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-5.1.0.tgz#b6e1c7d11a4e1d38ed0586a7847cd0f403c539e1"
+  integrity sha512-9Ekne+q8hfziJtnT9c1yDUBqT0eDMGgPrfPl4bpR3xwQHLTd/8gbSf6+IEkP/pjGsDZt1TGbC6emYmFYRbIXwQ==
+  dependencies:
+    cookie "^1.0.1"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"


### PR DESCRIPTION
## ✅ 체크리스트

- [x] kakao/google login redirect 연결
- [x] fetch api 함수의 기본 옵션으로 `credentials: 'include'` 추가
- [x] 쿠키에서 authorization 토큰 추출 `next-cookie`
- [x] 쿠키 헤더로 변환하는 API 요청 함수 구현
- [x] 사용자 토큰 스토어(useAuthStore) 구현

## 📝 작업 상세 내용

### fetch api 함수 기본 옵션 추가

> 요청 시 쿠키를 넘겨 주어야 하는 API가 대부분이라 fetchApi 함수의 기본 옵션으로 `credentials: 'include'`를 추가했습니다. 

```ts
  const response = await fetch(url, {
    ...options,
    credentials: 'include',
    headers: {
      'Content-Type': 'application/json',
      ...options.headers,
    },
  });
```

### 쿠키에서 authorization 토큰 추출

> 클라이언트 환경에서 쿠키를 가져오기 위해 `next-cookie` 라이브러리를 설치해 사용했습니다. 라이브러리 내장 함수인 getCookie를 통해 간편하게 쿠키를 가져와 스토어에 저장했습니다. 비회원일 경우 쿠키를 통해 인증 여부를 조회할 수 없어 해당 데이터 요청용으로만 사용됩니다.

```ts
import { getCookie } from 'cookies-next';

const useTokenStore = create<TokenState>(() => ({
  accessToken: getCookie('Authorization') as string | null,
}));
```

### 쿠키를 헤더로 변환하는 API 요청 함수 구현

> 쿠키 상태를 헤더로 변환해 주는 API 요청 함수(fetchAuthToken)를 구현했습니다. 쿠키에 담겨 있는 값을 요청과 함께 넘겨 줬을 때 응답 헤더에 사용자의 액세스 토큰이 반환됩니다. 사용자의 정보가 담긴 토큰을 `localStorage`에 저장하는 건 보안상 권장되지 않지만, 백엔드와 논의 후 가벼운 정보만 담겨 있는 토큰은 임시로 `localStorage`에 저장하고 사용하기로 결정했습니다. :> 별도의 데이터를 응답 값으로 전달받는 것은 아니라 요청 함수의 반환 값은 `null`입니다.

```ts
async function fetchAuthToken() {
  const endpoint = `${baseURL}/api/v1/user/auth/token`;

  const response = await fetch(endpoint, {
    method: 'GET',
    credentials: 'include',
  });

  if (!response.ok) throw new Error(`HTTP error status: ${response.status}`);

  const authorizationHeader = response.headers.get('Authorization');

  if (authorizationHeader) {
    const token = authorizationHeader.split(' ')[1];
    localStorage.setItem('accessToken', token);
  }

  return null;
}
```

### 사용자 토큰 스토어(useAuthStore) 구현

> 사용자의 인가 상태와 액세스 토큰을 관리하는 `useAuthStore`를 구현했습니다. 쿠키에 액세스 토큰이 있을 경우에만 `GNB` 내에서 `checkAuth()`를 통해 사용자의 로그인 여부 및 회원/비회원을 판단합니다. 아래와 같이 사용할 수 있습니다.

```ts
const { userToken, isAuthenticated } = useAuthStore();
```

```ts
const useAuthStore = create<AuthState & AuthStore>((set) => ({
  userToken: '',
  isAuthenticated: false,
  checkAuth: async () => {
    try {
      await fetchAuthToken();
    } catch (error) {
      throw Error(`토큰을 헤더로 변환할 수 없습니다. ${error}`);
    }
  },
  getAccessToken: () => {
    const accessToken = localStorage.getItem('accessToken') || null;

    if (accessToken) {
      set({ isAuthenticated: true });
      set({ userToken: accessToken });
    }
  },
}));
```

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #34 
