### PR TITLE
feat: 비회원 로그인 API 연동

### DIFF
--- a/zoo-client/middleware.ts
+++ b/zoo-client/middleware.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/insight-notes')) {
+    const token = request.cookies.get('Authorization');
+
+    if (!token) {
+      return NextResponse.redirect(new URL('/none-member', request.url));
+    }
+  }
+
+  if (pathname.startsWith('/mypage')) {
+    const token = request.cookies.get('Authorization');
+
+    if (!token) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/insight-notes/:path*', '/mypage/:path*'],
+};

--- a/zoo-client/src/app/insight-notes/page.tsx
+++ b/zoo-client/src/app/insight-notes/page.tsx
@@ -1,21 +1,29 @@
 'use client';
 
 import { Footer, NavigationBar, TopButton } from '@/components';
+import PrivatedRouter from '@/components/common/PrivatedRouter';
 import {
   GeneralInsightSection,
   TopSection,
+  LoginModal,
 } from '@/components/insight/insightNotes';
+import useAuthStore from '@/store/common/auth/useAuthStore';
 
 export default function Insights() {
+  const { userType } = useAuthStore();
+
   return (
-    <div className="m-auto flex flex-col items-center gap-60 bg-bg-primary text-text-main">
-      <NavigationBar />
-      <div className="flex w-[77.625rem] flex-col items-end gap-80">
-        <TopSection />
-        <GeneralInsightSection />
-        <TopButton />
+    <PrivatedRouter>
+      <div className="relative m-auto flex flex-col items-center gap-60 bg-bg-primary text-text-main">
+        <NavigationBar />
+        <div className="flex w-[77.625rem] flex-col items-end gap-80">
+          <TopSection />
+          <GeneralInsightSection />
+          <TopButton />
+        </div>
+        <Footer />
+        {userType === 'noneMember' && <LoginModal />}
       </div>
-      <Footer />
-    </div>
+    </PrivatedRouter>
   );
 }

--- a/zoo-client/src/components/common/PrivatedRouter.tsx
+++ b/zoo-client/src/components/common/PrivatedRouter.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+import useAuthStore from '@/store/common/auth/useAuthStore';
+
+interface IPrivatedRouterProps {
+  children: React.ReactNode;
+}
+
+const PrivatedRouter = ({ children }: IPrivatedRouterProps) => {
+  const { isAuthenticated } = useAuthStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isAuthenticated) router.push('/none-member');
+  }, [isAuthenticated, router]);
+
+  return <>{children}</>;
+};
+
+export default PrivatedRouter;

--- a/zoo-client/src/components/common/navigationBar/NavigationBar.tsx
+++ b/zoo-client/src/components/common/navigationBar/NavigationBar.tsx
@@ -5,9 +5,10 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
 import useAuthStore from '@/store/common/auth/useAuthStore';
-// import useTokenStore from '@/store/common/auth/useTokenStore';
+import useTokenStore from '@/store/common/auth/useTokenStore';
 import { OblongButton } from '@/components';
 import LogoIcon from '../logo/LogoIcon';
+import { deleteCookie } from 'cookies-next';
 
 interface INavigationBarProps {
   $type?: 'default' | 'main';
@@ -17,16 +18,29 @@ export default function NavigationBar({
   $type = 'default',
 }: INavigationBarProps) {
   const router = useRouter();
-  // const { accessToken } = useTokenStore();
+  const { accessToken } = useTokenStore();
+  const { isAuthenticated, getAccessToken } = useAuthStore();
   const checkAuth = useAuthStore((state) => state.checkAuth);
 
   useEffect(() => {
     const authenticate = async () => {
-      // if (accessToken) await checkAuth();
+      if (accessToken) await checkAuth();
     };
 
     authenticate();
+    getAccessToken();
   }, [checkAuth]);
+
+  const handleLogoutButton = () => {
+    localStorage.clear();
+    deleteCookie('Authorization');
+
+    useAuthStore.setState({
+      isAuthenticated: false,
+      userToken: null,
+      userType: 'none',
+    });
+  };
 
   const logoColorClasses = { default: '#4824FF', main: '#fff' };
   const labelColorClasses = {
@@ -52,12 +66,21 @@ export default function NavigationBar({
           <li className={`body-sb-16 ${labelColorClasses[$type]}`}>MY</li>
         </Link>
         <div className="w-[5.25rem]">
-          <OblongButton
-            text="Login"
-            size="xs"
-            $buttonStyle="primary"
-            onClick={() => router.push('/login')}
-          />
+          {isAuthenticated ? (
+            <OblongButton
+              text="Logout"
+              size="xs"
+              $buttonStyle="thirary"
+              onClick={handleLogoutButton}
+            />
+          ) : (
+            <OblongButton
+              text="Login"
+              size="xs"
+              $buttonStyle="primary"
+              onClick={() => router.push('/login')}
+            />
+          )}
         </div>
       </ul>
     </header>

--- a/zoo-client/src/components/common/textField/TextField.tsx
+++ b/zoo-client/src/components/common/textField/TextField.tsx
@@ -14,6 +14,7 @@ interface ITextField {
 
   name: string;
   rules?: RegisterOptions;
+  timer?: string;
 
   onButtonClick?: () => void;
   register: UseFormRegister<any>;
@@ -21,6 +22,7 @@ interface ITextField {
 
 export default function TextField({
   type,
+  timer,
   state = 'default',
   applyItem,
   buttonText,
@@ -67,7 +69,7 @@ export default function TextField({
         )}
       </div>
       {type === 'time' && (
-        <span className="figure-m-16 text-text-primary">05:00</span>
+        <span className="figure-m-16 text-text-primary">{timer}</span>
       )}
       {buttonText && onButtonClick && (
         <div className="w-[6.25rem]">

--- a/zoo-client/src/components/insight/insightNotes/GeneralInsightSection.tsx
+++ b/zoo-client/src/components/insight/insightNotes/GeneralInsightSection.tsx
@@ -12,9 +12,11 @@ import useInsightNoteTabStore from '@/store/common/insight/useInsightNoteTabStor
 import { selectedInsightDate, selectedInsightSort } from '@/constants/insights';
 import { InsightNoteTab, InsightCard, Tab } from '@/components';
 import { getTime } from '@/utils/insightDate';
+import useAuthStore from '@/store/common/auth/useAuthStore';
 
 export default function GeneralInsightSection() {
   const { data: sessions } = useSessions();
+  const { userType } = useAuthStore();
   const { currentDate } = useSessionStore();
   const { selectedTab } = useInsightNoteTabStore();
 
@@ -99,7 +101,7 @@ export default function GeneralInsightSection() {
           </section>
         </div>
       </div>
-      <div ref={lastElementRef} />
+      {userType === 'member' && <div ref={lastElementRef} />}
     </div>
   );
 }

--- a/zoo-client/src/components/insight/insightNotes/LoginModal.tsx
+++ b/zoo-client/src/components/insight/insightNotes/LoginModal.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from 'next/navigation';
+
+import ModalButton from '@/components/common/modal/Layout/ModalButton';
+import { IModalBodyProps } from '@/types/modal/modal';
+
+function NoneMemberOverlay() {
+  return (
+    <div className="bg-insights-overlay absolute bottom-0 left-0 h-[85rem] w-[100%]" />
+  );
+}
+
+function ModalBody({ bodyText }: IModalBodyProps) {
+  return (
+    <div className="flex w-[100%] items-center justify-center bg-bg-secondary px-20 py-24">
+      <p className="body-m-16 text-text-main">{bodyText}</p>
+    </div>
+  );
+}
+
+export default function LoginModal() {
+  const router = useRouter();
+
+  return (
+    <>
+      <NoneMemberOverlay />
+      <div className="absolute left-[50%] top-[50%] flex w-[50rem] translate-x-[-50%] translate-y-[-50%] flex-col items-center justify-center gap-0 rounded-[0.25rem] bg-bg-primary pb-32 pl-32 pr-32 pt-20">
+        <div className="flex w-[100%] flex-col items-center justify-center gap-20 p-0">
+          <header className="flex w-[100%] items-center justify-between">
+            <h4 className="title-sb-24 text-text-main">간편로그인</h4>
+          </header>
+          <ModalBody bodyText="로그인 후 더 많은 인사이트를 확인하세요." />
+          <ModalButton
+            buttonText="간편로그인 시작하기"
+            onButtonClick={() => router.push('/login')}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/zoo-client/src/components/insight/insightNotes/index.ts
+++ b/zoo-client/src/components/insight/insightNotes/index.ts
@@ -1,2 +1,3 @@
 export { default as TopSection } from './TopSection';
 export { default as GeneralInsightSection } from './GeneralInsightSection';
+export { default as LoginModal } from './LoginModal';

--- a/zoo-client/src/components/noneMember/NoneMemberForm.tsx
+++ b/zoo-client/src/components/noneMember/NoneMemberForm.tsx
@@ -5,48 +5,74 @@ import { useRouter } from 'next/navigation';
 import { AlertModal, OblongButton, TextField } from '@/components';
 import { useState } from 'react';
 import useModalStore from '@/store/common/useModalStore';
-
-interface FormData {
-  name: string;
-  email: string;
-  authenticationCode: string;
-}
+import {
+  fetchEmailVerification,
+  fetchNoneMemberLogin,
+  IUserInfo,
+} from '@/services/auth';
+import useTimer from '@/hooks/common/useTimer';
 
 export default function NoneMemberForm() {
   const router = useRouter();
   const [isAuthenticationClicked, setIsAuthenticationClicked] = useState(false);
   const { isOpen, contents, openModal, closeModal } = useModalStore();
+  const { timeRemaining, isTimerActive, startTimer, formatTime } =
+    useTimer(300);
 
   const {
     register,
     handleSubmit,
+    getValues,
     formState: { errors, isSubmitSuccessful },
-  } = useForm<FormData>({
+  } = useForm<IUserInfo>({
     defaultValues: {
       name: '',
       email: '',
-      authenticationCode: '',
+      code: '',
     },
   });
 
-  const onSubmit: SubmitHandler<FormData> = (data) => {
-    console.log(data);
-    if (isSubmitSuccessful) router.push('/session-schedule');
+  const onSubmit: SubmitHandler<IUserInfo> = async (data) => {
+    try {
+      await fetchNoneMemberLogin(data);
+      if (isSubmitSuccessful) router.push('/session-schedule');
+    } catch (error) {
+      throw Error(`비회원 로그인에 실패했습니다. ${error}`);
+    }
   };
 
-  const handleAuthenticationButton = () => {
+  const handleAuthenticationButton = async () => {
+    const email = getValues('email');
+
     openModal({
       contents: (
         <AlertModal
           headerText="비회원 이메일 인증"
           buttonText="확인"
           onButtonClick={closeModal}
-          bodyText={`서비스를 이용하려면 이메일 인증이 필요합니다.\n등록하신 [이메일]로 인증 메일을 발송했으니, 확인 후 인증을 완료해주세요.`}
+          bodyText={`서비스를 이용하려면 이메일 인증이 필요합니다.\n등록하신 [${email}]로 인증 메일을 발송했습니다.\n확인 후 인증을 완료해주세요.`}
         />
       ),
     });
 
-    setIsAuthenticationClicked(true);
+    try {
+      setIsAuthenticationClicked(true);
+
+      await fetchEmailVerification(email);
+      startTimer();
+    } catch (error) {
+      console.error(error);
+      openModal({
+        contents: (
+          <AlertModal
+            headerText="오류"
+            buttonText="확인"
+            onButtonClick={closeModal}
+            bodyText="이메일 인증 요청에 실패했습니다. 다시 시도해주세요."
+          />
+        ),
+      });
+    }
   };
 
   const openCancelModal = () => {
@@ -98,14 +124,15 @@ export default function NoneMemberForm() {
         <TextField
           readOnly={!isAuthenticationClicked}
           $isRequired
-          name="authenticationCode"
+          name="code"
           type={isAuthenticationClicked ? 'time' : 'default'}
           applyItem="인증 번호"
           placeholder="인증 번호"
           register={register}
-          state={errors.authenticationCode ? 'error' : 'default'}
+          timer={isTimerActive ? formatTime(timeRemaining) : '00:00'}
+          state={errors.code ? 'error' : 'default'}
           rules={{ required: '인증 번호은 필수 입력 항목입니다.' }}
-          errorMessage={errors.authenticationCode?.message}
+          errorMessage={errors.code?.message}
         />
         <span className="body-m-16 w-[100%] text-text-sub">
           본인 확인 절차이며, 다른 용도로 사용되지 않습니다.

--- a/zoo-client/src/hooks/common/useTimer.ts
+++ b/zoo-client/src/hooks/common/useTimer.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+function useTimer(initialTime: number) {
+  const [timeRemaining, setTimeRemaining] = useState(initialTime);
+  const [isTimerActive, setIsTimerActive] = useState(false);
+
+  const startTimer = () => {
+    setIsTimerActive(true);
+  };
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+
+    if (isTimerActive) {
+      timer = setInterval(() => {
+        setTimeRemaining((prev) => {
+          if (prev <= 0) {
+            clearInterval(timer);
+            setIsTimerActive(false);
+
+            return 0;
+          }
+
+          return prev - 1;
+        });
+      }, 1000);
+    }
+
+    return () => clearInterval(timer);
+  }, [isTimerActive]);
+
+  const formatTime = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  };
+
+  return { timeRemaining, isTimerActive, startTimer, formatTime };
+}
+
+export default useTimer;

--- a/zoo-client/src/services/auth.ts
+++ b/zoo-client/src/services/auth.ts
@@ -29,3 +29,31 @@ export async function fetchEmailVerification(email: string) {
     body: JSON.stringify({ email }),
   });
 }
+
+export interface IUserInfo {
+  name: string;
+  email: string;
+  code: string;
+}
+
+export async function fetchNoneMemberLogin({ name, email, code }: IUserInfo) {
+  const endpoint = `${baseURL}/api/v1/user/login`;
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    body: JSON.stringify({ name, email, code }),
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`HTTP error status: ${response.status}`);
+  }
+
+  const authorizationHeader = response.headers.get('Authorization');
+
+  if (authorizationHeader) {
+    const token = authorizationHeader.split(' ')[1];
+    localStorage.setItem('noneMemberAccessToken', token);
+  }
+
+  return null;
+}

--- a/zoo-client/src/services/auth.ts
+++ b/zoo-client/src/services/auth.ts
@@ -1,6 +1,7 @@
 import baseURL from '@/apis';
+import { fetchApi } from './api';
 
-async function fetchAuthToken() {
+export async function fetchAuthToken() {
   const endpoint = `${baseURL}/api/v1/user/auth/token`;
 
   const response = await fetch(endpoint, {
@@ -20,4 +21,11 @@ async function fetchAuthToken() {
   return null;
 }
 
-export default fetchAuthToken;
+export async function fetchEmailVerification(email: string) {
+  const endpoint = '/api/v1/user/email-auth';
+
+  return await fetchApi(endpoint, {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  });
+}

--- a/zoo-client/src/services/insight.ts
+++ b/zoo-client/src/services/insight.ts
@@ -5,9 +5,15 @@ import { InsightNoteListProps } from '@/types/insight/insightNote';
 
 export async function fetchTopInsights() {
   const endpoint = '/api/v1/insights/top';
+  const token =
+    localStorage.getItem('noneMemberAccessToken') ||
+    localStorage.getItem('accessToken');
 
   return fetchApi<IInsightContent[]>(endpoint, {
     method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   });
 }
 
@@ -22,6 +28,9 @@ export async function fetchInsights(
   sessionId?: number,
 ): Promise<TInsights> {
   let endpoint = `/api/v1/insights/list?&sort=${sort}&page=${page}`;
+  const token =
+    localStorage.getItem('noneMemberAccessToken') ||
+    localStorage.getItem('accessToken');
 
   if (eventDay && sessionId) {
     endpoint = `/api/v1/insights/list?&sort=${sort}&page=${page}&eventDay=${eventDay}&sessionId=${sessionId}`;
@@ -33,6 +42,9 @@ export async function fetchInsights(
 
   const response: ApiResponse<TInsights> = await fetchApi(endpoint, {
     method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   });
 
   return response.data;
@@ -45,8 +57,15 @@ export async function getInsightNote(
   size: number,
 ) {
   const endpoint = `/api/v1/sessions/${id}/insight-notes?sort=${sort}&page=${page}&size=${size}`;
+  const token =
+    localStorage.getItem('noneMemberAccessToken') ||
+    localStorage.getItem('accessToken');
+
   return fetchApi<InsightNoteListProps>(endpoint, {
     method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   });
 }
 

--- a/zoo-client/src/store/common/auth/useAuthStore.ts
+++ b/zoo-client/src/store/common/auth/useAuthStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import fetchAuthToken from '@/services/auth';
+import { fetchAuthToken } from '@/services/auth';
 
 interface AuthState {
   checkAuth: () => Promise<void>;
@@ -9,10 +9,12 @@ interface AuthState {
 interface AuthStore {
   isAuthenticated: boolean;
   userToken: string | null;
+  userType: 'noneMember' | 'member' | 'none';
 }
 
 const useAuthStore = create<AuthState & AuthStore>((set) => ({
-  userToken: '',
+  userType: 'none',
+  userToken: null,
   isAuthenticated: false,
   checkAuth: async () => {
     try {
@@ -23,10 +25,23 @@ const useAuthStore = create<AuthState & AuthStore>((set) => ({
   },
   getAccessToken: () => {
     const accessToken = localStorage.getItem('accessToken') || null;
+    const noneMemberAccessToken =
+      localStorage.getItem('noneMemberAccessToken') || null;
 
     if (accessToken) {
-      set({ isAuthenticated: true });
-      set({ userToken: accessToken });
+      set({
+        isAuthenticated: true,
+        userToken: accessToken,
+        userType: 'member',
+      });
+    } else if (noneMemberAccessToken) {
+      set({
+        isAuthenticated: true,
+        userToken: noneMemberAccessToken,
+        userType: 'noneMember',
+      });
+    } else {
+      set({ isAuthenticated: false, userToken: null, userType: 'none' });
     }
   },
 }));

--- a/zoo-client/tailwind.config.ts
+++ b/zoo-client/tailwind.config.ts
@@ -18,6 +18,8 @@ export default {
       spacing,
       backgroundImage: {
         'custom-gradient': 'linear-gradient(145deg, #000127 0%, #000235 100%)',
+        'insights-overlay':
+          'linear-gradient(180deg, rgba(255, 255, 255, 0.40) 0%, rgba(246, 246, 246, 0.90) 19%, #FFF 100%)',
       },
     },
   },


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 비회원 로그인 API 연동 (이메일 인증/비회원 로그인)
- [x] 사용자가 비회원일 경우 인사이트 목록 gradient 처리

## 📝 작업 상세 내용

> 비회원 로그인 API 연동이 완료되었습니다. 이제 `useAuthStore`의 `userType`을 통해 비회원 여부를 판단할 수 있습니다.

![스크린샷 2025-03-27 오후 8 11 15](https://github.com/user-attachments/assets/0b079906-dab0-4ce3-9613-fa13792548a0)

> 비회원 여부를 판단해 인사이트 목록 페이지 접근 시 오버레이와 함께 모달이 표시되도록 추가 구현했습니다.

![스크린샷 2025-03-27 오후 8 09 13](https://github.com/user-attachments/assets/448176ea-c321-4a0d-b612-93dbb9219e13)

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

## 📸 스크린샷 (선택 사항)

## ✅ 셀프 체크리스트

- [x]  브랜치 확인하기
- [x]  불필요한 코드가 들어가지 않았는지 재확인하기
- [x]  issue 닫기
- [x]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #55 
