### PR TITLE
feat: 마이 페이지 인사이트 UI & API 연동

### DIFF
--- a/zoo-client/src/app/mypage/@content/insights/page.tsx
+++ b/zoo-client/src/app/mypage/@content/insights/page.tsx
@@ -1,3 +1,124 @@
+'use client';
+import { Tab } from '@/components';
+import { useSessionStore } from '@/store/common/useSessionStore';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { selectedInsightDate } from '@/constants/insights';
+import useObserver from '@/hooks/common/useObserver';
+import { useGetInfiniteMyInsightNote } from '@/hooks/insights/useInsights';
+import { IMyNote } from '@/types/insight/insightNote';
+
+function InsightItems({ note }: IMyNote) {
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [isDetailed, setIsDetailed] = useState(false);
+  const { memo, isPublic, sessionName } = note;
+
+  useEffect(() => {
+    if (textRef.current) {
+      setIsOverflowing(textRef.current.scrollHeight > 120);
+    }
+  }, []);
+
+  return (
+    <>
+      <div className="flex flex-col gap-2 p-6">
+        <div className="flex items-center gap-2">
+          <div className="body-m-16-150 bg-bg-secondary px-2 py-1 text-text-main">
+            {isPublic ? '공개' : '비공개'}
+          </div>
+          <h3>{sessionName}</h3>
+        </div>
+        <p
+          ref={textRef}
+          className="body-r-16-150 overflow-hidden text-text-sub"
+          style={{ maxHeight: isDetailed ? '1000px' : '120px' }}
+        >
+          {memo}
+        </p>
+        {isOverflowing && (
+          <div
+            onClick={() => setIsDetailed(!isDetailed)}
+            className="body-r-14 flex cursor-pointer items-center gap-1 text-text-sub"
+          >
+            <span>{isDetailed ? '닫기' : '자세히 보기'}</span>
+            <Image
+              height={24}
+              width={24}
+              src="/button/down-arrow.svg"
+              alt="down-arrow"
+              className={`transition-transform duration-300 ease-in-out ${isDetailed ? 'rotate-180' : ''}`}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function InsightList() {
+  const lastRef = useRef<HTMLDivElement | null>(null);
+  const { currentDate } = useSessionStore();
+
+  const {
+    data: myInsights,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetInfiniteMyInsightNote(selectedInsightDate[currentDate]);
+
+  console.log(myInsights);
+  useObserver({
+    target: lastRef,
+    onIntersect: ([entry]) => {
+      if (entry.isIntersecting && hasNextPage) fetchNextPage();
+    },
+  });
+  return (
+    <div className="flex w-full flex-col shadow-lg">
+      {myInsights?.pages.map((page) => {
+        return page?.content.map((list, index) => (
+          <InsightItems key={index} note={list} />
+        ));
+      })}
+      {hasNextPage && <div ref={lastRef}></div>}
+    </div>
+  );
+}
+
 export default function MyInsights() {
-  return <div className="">Insights</div>;
+  const router = useRouter();
+  return (
+    <div className="flex flex-col gap-10">
+      <div>
+        <h1 className="headline-sb-36 leading-normal text-text-main">
+          내 인사이트 노트
+        </h1>
+        <p className="body-m-16 text-text-sub">
+          필요할 때 꺼내 보며, 아이디어 정리하고 새로운 관점을 더해 보세요
+        </p>
+      </div>
+      <div className="flex flex-col gap-36">
+        <Tab />
+        <div className="flex w-full flex-col items-end">
+          <div
+            onClick={() => router.push('/insight-notes')}
+            className="flex items-center"
+          >
+            <label className="text-text-sub">인사이트 노트 작성하러 가기</label>
+            <button>
+              <Image
+                src={'/button/right-arrow-side-in.svg'}
+                alt="자세히 보기"
+                width={24}
+                height={24}
+                className="cursor-pointer"
+              />
+            </button>
+          </div>
+          <InsightList />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/zoo-client/src/app/mypage/@content/sessions/[id]/page.tsx
+++ b/zoo-client/src/app/mypage/@content/sessions/[id]/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import SessionDetailModal from '@/components/common/modal/SessionDetailModal';
+import { SessionId } from '@/types/session/session';
+import { useParams, useRouter } from 'next/navigation';
+import { useSession } from '@/hooks/session/useSession';
+import MySessions from '../page';
+
+export default function MySessionDetailPage() {
+  const router = useRouter();
+  const sessionId = useParams().id as string;
+  const { data: currentSession = {} as SessionId, isLoading } = useSession(
+    Number(sessionId),
+  );
+
+  const handleClose = () => {
+    router.back();
+  };
+
+  return (
+    <>
+      <MySessions />
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-bg-black/40"
+        onClick={handleClose}
+      >
+        {!isLoading && (
+          <div
+            className="flex max-w-[800px] flex-col rounded-sm bg-bg-primary p-32 text-text-main shadow-md"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <SessionDetailModal currentSession={currentSession} />
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/zoo-client/src/app/mypage/@content/sessions/page.tsx
+++ b/zoo-client/src/app/mypage/@content/sessions/page.tsx
@@ -60,9 +60,7 @@ function HasTicketList({ registeredSessions }: IRegisteredSessions) {
                         <div className="flex justify-end">
                           <button
                             onClick={() =>
-                              router.push(
-                                `/sessions/${sessionId}/insight-notes`,
-                              )
+                              router.push(`/mypage/sessions/${sessionId}`)
                             }
                             className="bg-bg-secondary px-16 py-3 text-text-primary"
                           >

--- a/zoo-client/src/app/session-apply/page.tsx
+++ b/zoo-client/src/app/session-apply/page.tsx
@@ -9,7 +9,6 @@ import {
   Tab,
 } from '@/components';
 import { SESSION_APPLY_MESSAGES } from '@/constants/messages';
-import { useSessions } from '@/hooks/session/useSession';
 import useModalStore from '@/store/common/useModalStore';
 
 const Title = () => {
@@ -49,7 +48,6 @@ const AccordionContainer = () => {
 };
 
 export default function SessionApply() {
-  const { data: sessions } = useSessions();
   const { isOpen, contents } = useModalStore();
 
   return (
@@ -63,7 +61,7 @@ export default function SessionApply() {
             <RadioContainer />
           </div>
           <div className="flex flex-col gap-60">
-            <Tab sessionList={sessions} />
+            <Tab />
             <AccordionContainer />
           </div>
         </div>

--- a/zoo-client/src/app/session-schedule/page.tsx
+++ b/zoo-client/src/app/session-schedule/page.tsx
@@ -10,7 +10,6 @@ import {
 import { SESSION_SCHEDULE_MESSAGES } from '@/constants/messages';
 import useButtonAccess from '@/hooks/access/useButtonAccess';
 import { useKeywords } from '@/hooks/session/useKeywords';
-import { useSessions } from '@/hooks/session/useSession';
 
 const Title = () => {
   const { hide, handler } = useButtonAccess();
@@ -46,15 +45,13 @@ const SessionAccordion = () => {
 };
 
 export default function SessionSchedulePage() {
-  const { data: sessions } = useSessions();
-
   return (
     <main className="flex flex-col items-center bg-bg-primary">
       <NavigationBar />
       <div className="m-[100px] flex w-full max-w-[1240px] flex-col gap-40">
         <Title />
         <SessionAccordion />
-        <Tab sessionList={sessions} />
+        <Tab />
         <SessionList />
       </div>
     </main>

--- a/zoo-client/src/components/common/modal/SessionDetailModal.tsx
+++ b/zoo-client/src/components/common/modal/SessionDetailModal.tsx
@@ -3,13 +3,14 @@ import { PurchaseButton, SessionInfo } from '@/components';
 import { SESSION_SCHEDULE_MESSAGES } from '@/constants/messages';
 import { useApplyStore } from '@/store/common/useApplyStore';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { ISessionId } from '@/types/session/session';
 import ModalContainer from './Layout/ModalContainer';
 import ModalHeader from './Layout/ModalHeader';
 
 const ModalBody = ({ currentSession }: ISessionId) => {
   const { setModalType } = useApplyStore();
+  const pathname = usePathname();
 
   return (
     <div className="size-full">
@@ -38,18 +39,19 @@ const ModalBody = ({ currentSession }: ISessionId) => {
         <span className="body-sb-20">세션 이력</span>
         <span className="body-m-16-150">없으면 표기 안 함</span>
       </div>
-      <PurchaseButton
-        func={() => setModalType('primary')}
-        size={48}
-        text={SESSION_SCHEDULE_MESSAGES.buttonModalText}
-      />
+      <div className={pathname.startsWith('/mypage') ? 'hidden' : 'block'}>
+        <PurchaseButton
+          func={() => setModalType('primary')}
+          size={48}
+          text={SESSION_SCHEDULE_MESSAGES.buttonModalText}
+        />
+      </div>
     </div>
   );
 };
 
 export default function SessionDetailModal({ currentSession }: ISessionId) {
   const router = useRouter();
-
   const closeModal = () => {
     router.back();
   };

--- a/zoo-client/src/components/common/navigationBar/InsightSideNavigationBar.tsx
+++ b/zoo-client/src/components/common/navigationBar/InsightSideNavigationBar.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useSessions } from '@/hooks/session/useSession';
+import { useGetTicket } from '@/hooks/session/useReservation';
+import { UserTicket } from '@/types/ticket/ticket';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -27,11 +28,17 @@ const SessionListItems = ({ name, id }: SessionSNBProps) => {
 
 export default function InsightSideNavigationBar() {
   const [onList, setOnList] = useState(false);
-  const { data = [] } = useSessions();
-  const sessions = Object.values(data).flatMap((date) =>
-    date.flatMap((timeList) => timeList.sessions),
+  const { data: tickets = {} as UserTicket } = useGetTicket();
+  const registeredSessions = tickets.registeredSessions;
+  const sessions = Object.values(registeredSessions).flatMap(
+    (registeredSessions) =>
+      registeredSessions.map(({ sessionName, sessionId }) => ({
+        name: sessionName,
+        id: sessionId,
+      })),
   );
 
+  console.log('sessions', sessions);
   return (
     <>
       {!onList ? (

--- a/zoo-client/src/components/common/navigationBar/NavigationBar.tsx
+++ b/zoo-client/src/components/common/navigationBar/NavigationBar.tsx
@@ -9,6 +9,8 @@ import useTokenStore from '@/store/common/auth/useTokenStore';
 import { OblongButton } from '@/components';
 import LogoIcon from '../logo/LogoIcon';
 import { deleteCookie } from 'cookies-next';
+import { useGetTicket } from '@/hooks/session/useReservation';
+import { UserTicket } from '@/types/ticket/ticket';
 
 interface INavigationBarProps {
   $type?: 'default' | 'main';
@@ -21,6 +23,12 @@ export default function NavigationBar({
   const { accessToken } = useTokenStore();
   const { isAuthenticated, getAccessToken } = useAuthStore();
   const checkAuth = useAuthStore((state) => state.checkAuth);
+  const { data: tickets = {} as UserTicket } = useGetTicket();
+
+  const sessionId =
+    tickets &&
+    tickets.registeredSessions &&
+    Object.values(tickets.registeredSessions)[0][0]?.sessionId;
 
   useEffect(() => {
     const authenticate = async () => {
@@ -57,7 +65,7 @@ export default function NavigationBar({
         <Link href="/session-schedule">
           <li className={`body-sb-16 ${labelColorClasses[$type]}`}>세션</li>
         </Link>
-        <Link href="/insight-notes">
+        <Link href={`/sessions/${sessionId}/insight-notes`}>
           <li className={`body-sb-16 ${labelColorClasses[$type]}`}>
             인사이트 노트
           </li>

--- a/zoo-client/src/components/common/profile/CardProfile.tsx
+++ b/zoo-client/src/components/common/profile/CardProfile.tsx
@@ -24,7 +24,6 @@ interface IProfileProps {
 
 function DetailButton({ contentId }: IDetailButtonProps) {
   const router = useRouter();
-
   return (
     <button
       onClick={() =>

--- a/zoo-client/src/components/common/tab/Tab.tsx
+++ b/zoo-client/src/components/common/tab/Tab.tsx
@@ -5,15 +5,17 @@ import { useEffect } from 'react';
 import { useSessionStore } from '@/store/common/useSessionStore';
 import ToggleButton from './ToggleButton';
 import { usePathname } from 'next/navigation';
-export default function Tab({ sessionList = {} }) {
+import { useSessions } from '@/hooks/session/useSession';
+export default function Tab() {
   const { sessionDates, addSessionDate } = useSessionStore();
   const isSchedulePath = usePathname().includes('session-apply');
+  const { data: sessions } = useSessions();
 
   useEffect(() => {
-    if (sessionList && typeof sessionList === 'object') {
-      Object.keys(sessionList).forEach((date) => addSessionDate(`${date}`));
+    if (sessions && typeof sessions === 'object') {
+      Object.keys(sessions).forEach((date) => addSessionDate(`${date}`));
     }
-  }, [addSessionDate, sessionList]);
+  }, [addSessionDate, sessions]);
 
   return (
     <div className="flex w-full items-center justify-between bg-bg-secondary px-20 py-16">

--- a/zoo-client/src/components/insight/insightNotes/GeneralInsightSection.tsx
+++ b/zoo-client/src/components/insight/insightNotes/GeneralInsightSection.tsx
@@ -6,7 +6,6 @@ import {
   useHorizontalInsightsQuery,
 } from '@/hooks/insights/insight';
 import useObserver from '@/hooks/common/useObserver';
-import { useSessions } from '@/hooks/session/useSession';
 import { useSessionStore } from '@/store/common/useSessionStore';
 import useInsightNoteTabStore from '@/store/common/insight/useInsightNoteTabStore';
 import { selectedInsightDate, selectedInsightSort } from '@/constants/insights';
@@ -15,7 +14,6 @@ import { getTime } from '@/utils/insightDate';
 import useAuthStore from '@/store/common/auth/useAuthStore';
 
 export default function GeneralInsightSection() {
-  const { data: sessions } = useSessions();
   const { userType } = useAuthStore();
   const { currentDate } = useSessionStore();
   const { selectedTab } = useInsightNoteTabStore();
@@ -57,7 +55,7 @@ export default function GeneralInsightSection() {
 
   return (
     <div className="flex w-[100%] flex-col items-center gap-40">
-      <Tab sessionList={sessions} />
+      <Tab />
       <div className="flex w-[100%] flex-col items-center justify-center gap-40">
         <div className="flex w-[100%] flex-col content-center items-center gap-8">
           <div className="flex w-[100%] items-center justify-between px-0 py-12">

--- a/zoo-client/src/components/insight/note/NoteItem.tsx
+++ b/zoo-client/src/components/insight/note/NoteItem.tsx
@@ -55,7 +55,7 @@ export default function NoteItem({ children, note }: IChildren & INote) {
               onClick={() => setDetailedReply(!detailedReply)}
               className="body-r-14 flex cursor-pointer items-center gap-1 text-text-sub"
             >
-              <span>{detailedReply ? '닫기' : '자세히보기'}</span>
+              <span>{detailedReply ? '닫기' : '자세히 보기'}</span>
               <Image
                 height={24}
                 width={24}

--- a/zoo-client/src/hooks/insights/useInsights.ts
+++ b/zoo-client/src/hooks/insights/useInsights.ts
@@ -1,5 +1,9 @@
 import { createNote } from '@/actions/insight-form';
-import { getInsightDetailed, getInsightNote } from '@/services/insight';
+import {
+  getInsightDetailed,
+  getInsightNote,
+  getMyInsights,
+} from '@/services/insight';
 import {
   useMutation,
   useQuery,
@@ -20,6 +24,27 @@ export const useGetInsightNote = (id: number, sort: string, size?: number) => {
     queryKey: insightsQueryKey(id, sort),
     queryFn: async ({ pageParam }) => {
       const res = await getInsightNote(id, pageParam, sort, size ? size : 4);
+      return res.data;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (last) => {
+      if (last && last.pageNumber + 1 < last.totalPages) {
+        return last.pageNumber + 1;
+      }
+      return undefined;
+    },
+  });
+};
+
+export const useGetInfiniteMyInsightNote = (eventDay: string) => {
+  return useInfiniteQuery({
+    queryKey: ['insights', eventDay],
+    queryFn: async ({ pageParam }) => {
+      const res = await getMyInsights({
+        eventDay: eventDay,
+        page: pageParam,
+        size: 5,
+      });
       return res.data;
     },
     initialPageParam: 0,

--- a/zoo-client/src/services/insight.ts
+++ b/zoo-client/src/services/insight.ts
@@ -1,7 +1,10 @@
 import { fetchApi } from './api';
 import { IInsightContent, TInsights } from '@/types/insight/insightCard';
 import { InsightDetailedProps } from '@/types/insight/insight';
-import { InsightNoteListProps } from '@/types/insight/insightNote';
+import {
+  InsightNoteListProps,
+  MyInsightNoteListProps,
+} from '@/types/insight/insightNote';
 
 export async function fetchTopInsights() {
   const endpoint = '/api/v1/insights/top';
@@ -72,6 +75,25 @@ export async function getInsightNote(
 export async function getInsightDetailed(id: number) {
   const endpoint = `/api/v1/insights/${id}`;
   return fetchApi<InsightDetailedProps>(endpoint, {
+    method: 'GET',
+  });
+}
+
+export async function getMyInsights({
+  eventDay,
+  page,
+  size,
+}: {
+  eventDay?: string;
+  page: number;
+  size: number;
+}) {
+  const endpoint = eventDay
+    ? `/api/v1/my/insights?eventDay=${eventDay}&page=${page}&size=${size}`
+    : `/api/v1/my/insights?page=${page}&size=${size}`;
+
+  console.log(endpoint);
+  return fetchApi<MyInsightNoteListProps>(endpoint, {
     method: 'GET',
   });
 }

--- a/zoo-client/src/types/insight/insightNote.ts
+++ b/zoo-client/src/types/insight/insightNote.ts
@@ -29,3 +29,25 @@ export interface InsightNoteListProps {
   pageSize: number;
   content: InsightNoteProps[];
 }
+
+export interface MyInsightNoteProps {
+  insightId: number;
+  memo: string;
+  isPublic: boolean;
+  isAnonymous: boolean;
+  updatedAt: string;
+  sessionName: string;
+  isDraft: boolean;
+}
+
+export interface IMyNote {
+  note: MyInsightNoteProps;
+}
+export interface MyInsightNoteListProps {
+  hasNext: boolean;
+  totalElements: number;
+  totalPages: number;
+  pageNumber: number;
+  pageSize: number;
+  content: MyInsightNoteProps[];
+}

--- a/zoo-client/src/utils/insightDate.ts
+++ b/zoo-client/src/utils/insightDate.ts
@@ -4,12 +4,16 @@ export function getTime(updatedAt: string) {
 
   const differenceTime = currentTime.getTime() - updatedTime.getTime();
 
+  if (differenceTime < 0) return '방금 전';
+
   const writedDays = Math.floor(differenceTime / (1000 * 60 * 60 * 24));
-  const writedHours = Math.floor(differenceTime / (1000 * 60 * 60));
-  const writedMinutes = Math.floor(differenceTime / (1000 * 60));
-
   if (writedDays > 0) return `${writedDays}일 전`;
-  else if (writedHours > 0) return `${writedHours}시간 전`;
 
-  return `${writedMinutes}분 전`;
+  const writedHours = Math.floor(differenceTime / (1000 * 60 * 60));
+  if (writedHours > 0) return `${writedHours}시간 전`;
+
+  const writedMinutes = Math.floor(differenceTime / (1000 * 60));
+  if (writedMinutes > 0) return `${writedMinutes}분 전`;
+
+  return '방금 전';
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [X]  마이페이지 인사이트 연동

## 📝 작업 상세 내용

##  ☑️ 인사이트 UI 구현 및 API 연동
![image](https://github.com/user-attachments/assets/f7650f86-838d-4dd6-a202-505dd8217844)
- 인사이트 노트 작성하러 가기 버튼은 일단 인사이트 전체 페이지로 라우팅 되게끔 하였습니다

##  ☑️ 세션 리스트 상세 보기 Btn
![image](https://github.com/user-attachments/assets/76a58722-0cee-4534-b1b2-8b86f985b048)
- 해당 버튼 클릭 시 세션 상세 모달을 보여 줍니다

## ☑️ 인사이트 작성 페이지 내 SNB
![image](https://github.com/user-attachments/assets/547f9312-f8f8-40eb-ac2c-335566c83681)
- 티켓 정보를 받아와 전체 세션 리스트 대신 결제한 세션 리스트를 노출합니다

## 🚨 버그 발생 이유 (선택 사항)

## 🔎 후속 작업 (선택 사항)

## 🤔 질문 사항 (선택 사항)

## 📚 참고 자료 (선택 사항)

추가적인 참고 사항이나 관련된 문서, 링크 등을 제공해주세요.

## 📸 스크린샷 (선택 사항)

변경 사항에 대한 스크린샷이 있다면 첨부해주세요.

## ✅ 셀프 체크리스트

- [X]  브랜치 확인하기
- [X]  불필요한 코드가 들어가지 않았는지 재확인하기
- [X]  issue 닫기
- [X]  reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #61
